### PR TITLE
Added ConstFloat to allow LE versions of floats to be parsed.

### DIFF
--- a/protospec-build/src/asg/expression/const_float.rs
+++ b/protospec-build/src/asg/expression/const_float.rs
@@ -1,0 +1,135 @@
+use super::*;
+
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub enum ConstFloat {
+    F32(f32),
+    F64(f64),
+}
+
+macro_rules! const_float_op {
+    ($e1: expr, $i1: ident, $op: expr) => {
+        match $e1 {
+            ConstFloat::F32($i1) => $op,
+            ConstFloat::F64($i1) => $op,
+        }
+    };
+}
+
+macro_rules! const_float_map {
+    ($e1: expr, $i1: ident, $sop: expr, $usop: expr) => {
+        match $e1 {
+            ConstFloat::F32($i1) => Some(ConstFloat::F32($usop)),
+            ConstFloat::F64($i1) => Some(ConstFloat::F64($usop)),
+        }
+    };
+}
+
+macro_rules! const_float_biop_map {
+    ($e1: expr, $e2: expr, $i1: ident, $i2: ident, $op: expr) => {
+        match ($e1, $e2) {
+            (ConstFloat::F32($i1), ConstFloat::F32($i2)) => Some(ConstFloat::F32($op)),
+            (ConstFloat::F64($i1), ConstFloat::F64($i2)) => Some(ConstFloat::F64($op)),
+            _ => None,
+        }
+    };
+}
+
+impl Add for ConstFloat {
+    type Output = Option<Self>;
+
+    fn add(self, other: Self) -> Self::Output {
+        const_float_biop_map!(self, other, i1, i2, i1 + i2)
+    }
+}
+
+impl Sub for ConstFloat {
+    type Output = Option<Self>;
+
+    fn sub(self, other: Self) -> Self::Output {
+        const_float_biop_map!(self, other, i1, i2, i1 - i2)
+    }
+}
+
+impl Mul for ConstFloat {
+    type Output = Option<Self>;
+
+    fn mul(self, other: Self) -> Self::Output {
+        const_float_biop_map!(self, other, i1, i2, i1 * i2)
+    }
+}
+
+impl Div for ConstFloat {
+    type Output = Option<Self>;
+
+    fn div(self, other: Self) -> Self::Output {
+        const_float_biop_map!(self, other, i1, i2, i1 / i2)
+    }
+}
+
+impl Rem for ConstFloat {
+    type Output = Option<Self>;
+
+    fn rem(self, other: Self) -> Self::Output {
+        const_float_biop_map!(self, other, i1, i2, i1 % i2)
+    }
+}
+
+impl Neg for ConstFloat {
+    type Output = Option<Self>;
+
+    #[allow(unreachable_code, unused_variables)]
+    fn neg(self) -> Self::Output {
+        const_float_map!(self, i1, -i1, unimplemented!("cannot neg unsigned value"))
+    }
+}
+
+
+impl ConstFloat {
+    pub fn cast_to(&self, target: ScalarType) -> Self {
+        const_float_op!(
+            self,
+            i1,
+            match target {
+                ScalarType::F32 => ConstFloat::F32(*i1 as f32),
+                ScalarType::F64 => ConstFloat::F64(*i1 as f64),
+                _ => panic!("This isn't a float, but an int!"),
+            }
+        )
+    }
+
+    pub fn parse(scalar_type: ScalarType, value: &str, span: Span) -> AsgResult<ConstFloat> {
+        if value.starts_with("0x") {
+            let value = &value[2..];
+            return Ok(match scalar_type {
+                ScalarType::F32 => ConstFloat::F32(
+                    value
+                        .parse::<f32>()
+                        .map_err(|_| AsgError::InvalidInt(value.to_string(), span))?,
+                ),
+                ScalarType::F64 => ConstFloat::F64(
+                    value
+                        .parse::<f64>()
+                        .map_err(|_| AsgError::InvalidInt(value.to_string(), span))?,
+                ),
+                _ => {
+                    panic!("This isn't a float, but an int!")
+                }
+            });
+        }
+        Ok(match scalar_type {
+            ScalarType::F32 => ConstFloat::F32(
+                value
+                    .parse::<f32>()
+                    .map_err(|_| AsgError::InvalidInt(value.to_string(), span))?,
+            ),
+            ScalarType::F64 => ConstFloat::F64(
+                value
+                    .parse::<f64>()
+                    .map_err(|_| AsgError::InvalidInt(value.to_string(), span))?,
+            ),
+            _ => {
+                panic!("This isn't a float, but an int!")
+            }
+        })
+    }
+}

--- a/protospec-build/src/asg/expression/const_int.rs
+++ b/protospec-build/src/asg/expression/const_int.rs
@@ -203,6 +203,7 @@ impl ConstInt {
                 ScalarType::U32 => ConstInt::U32(*i1 as u32),
                 ScalarType::U64 => ConstInt::U64(*i1 as u64),
                 ScalarType::U128 => ConstInt::U128(*i1 as u128),
+                _ => panic!("This isn't an int, but a float!"),
             }
         )
     }
@@ -251,6 +252,7 @@ impl ConstInt {
                     u128::from_str_radix(value, 16)
                         .map_err(|_| AsgError::InvalidInt(value.to_string(), span))?,
                 ),
+                _ => panic!("This isn't an int, but a float!"),
             });
         }
         Ok(match scalar_type {
@@ -304,6 +306,7 @@ impl ConstInt {
                     .parse()
                     .map_err(|_| AsgError::InvalidInt(value.to_string(), span))?,
             ),
+            _ => panic!("This isn't an int, but a float!"),
         })
     }
 }

--- a/protospec-build/src/asg/expression/mod.rs
+++ b/protospec-build/src/asg/expression/mod.rs
@@ -24,6 +24,9 @@ pub use call::*;
 mod const_int;
 pub use const_int::*;
 
+mod const_float;
+pub use const_float::*;
+
 mod int;
 pub use int::*;
 

--- a/protospec-build/src/ast/types/scalar.rs
+++ b/protospec-build/src/ast/types/scalar.rs
@@ -18,6 +18,8 @@ pub enum ScalarType {
     I32,
     I64,
     I128,
+    F32,
+    F64
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Copy, Debug)]
@@ -61,6 +63,8 @@ impl ScalarType {
             ScalarType::I32 | ScalarType::U32 => 4,
             ScalarType::I64 | ScalarType::U64 => 8,
             ScalarType::I128 | ScalarType::U128 => 16,
+            ScalarType::F32 => 4,
+            ScalarType::F64 => 8,
         }
     }
 }
@@ -82,6 +86,8 @@ impl fmt::Display for ScalarType {
                 I32 => "i32",
                 I64 => "i64",
                 I128 => "i128",
+                F32 => "f32",
+                F64 => "f64",
             }
         )
     }

--- a/protospec-build/src/parser/types/scalar.rs
+++ b/protospec-build/src/parser/types/scalar.rs
@@ -13,6 +13,8 @@ pub fn parse_scalar_type(t: &mut TokenIter) -> Option<EndianScalarType> {
             Token::U32,
             Token::U64,
             Token::U128,
+            Token::F32,
+            Token::F64,
             Token::I16Le,
             Token::I32Le,
             Token::I64Le,
@@ -21,6 +23,8 @@ pub fn parse_scalar_type(t: &mut TokenIter) -> Option<EndianScalarType> {
             Token::U32Le,
             Token::U64Le,
             Token::U128Le,
+            Token::F32Le,
+            Token::F64Le,
         ])
         .ok()?;
     let scalar = match token {
@@ -34,6 +38,8 @@ pub fn parse_scalar_type(t: &mut TokenIter) -> Option<EndianScalarType> {
         Token::U32 => ScalarType::U32,
         Token::U64 => ScalarType::U64,
         Token::U128 => ScalarType::U128,
+        Token::F32 => ScalarType::F32,
+        Token::F64 => ScalarType::F64,
         Token::I16Le => ScalarType::I16,
         Token::I32Le => ScalarType::I32,
         Token::I64Le => ScalarType::I64,
@@ -42,6 +48,8 @@ pub fn parse_scalar_type(t: &mut TokenIter) -> Option<EndianScalarType> {
         Token::U32Le => ScalarType::U32,
         Token::U64Le => ScalarType::U64,
         Token::U128Le => ScalarType::U128,
+        Token::F32Le => ScalarType::F32,
+        Token::F64Le => ScalarType::F64,
         _ => return None,
     };
     Some(EndianScalarType {
@@ -55,6 +63,8 @@ pub fn parse_scalar_type(t: &mut TokenIter) -> Option<EndianScalarType> {
             Token::U32Le => Endian::Little,
             Token::U64Le => Endian::Little,
             Token::U128Le => Endian::Little,
+            Token::F32Le => Endian::Little,
+            Token::F64Le => Endian::Little,
             _ => Endian::Big,
         },
     })

--- a/protospec-build/src/tokenizer.rs
+++ b/protospec-build/src/tokenizer.rs
@@ -42,6 +42,8 @@ pub enum Token {
     I128Le,
     F32,
     F64,
+    F32Le,
+    F64Le,
     Bool,
     Lt,
     Gt,
@@ -126,6 +128,8 @@ impl fmt::Display for Token {
             I128Le => write!(f, "i128le "),
             F32 => write!(f, "f32 "),
             F64 => write!(f, "f64 "),
+            F32Le => write!(f, "f32le "),
+            F64Le => write!(f, "f64le "),
             Bool => write!(f, "bool "),
             Lt => write!(f, "< "),
             Gt => write!(f, "> "),
@@ -437,6 +441,8 @@ impl Token {
                     "container" => Token::Container,
                     "f32" => Token::F32,
                     "f64" => Token::F64,
+                    "f32le" => Token::F32Le,
+                    "f64le" => Token::F64Le,
                     "enum" => Token::Enum,
                     "default" => Token::Default,
                     "bitfield" => Token::Bitfield,
@@ -636,6 +642,8 @@ mod tests {
         test block*/container
         f32
         f64
+        f32le
+        f64le
         enum
         default
         bitfield
@@ -657,7 +665,7 @@ mod tests {
             output,
             r#"test_ident"string""str"ing""str\ing"12345-12345type as import import_ffi i8 u8 i16le u16le transform function const /*
 
-        test block*/ container f32 f64 enum default bitfield true false bool from ,;:?[]{}< > ?+-/ *%.. <= >= = == != ! ()// test$
+        test block*/ container f32 f64 f32le f64le enum default bitfield true false bool from ,;:?[]{}< > ?+-/ *%.. <= >= = == != ! ()// test$
 :> || && | ^| >> << >>> ~. ?: //
 "#
         );


### PR DESCRIPTION
I've seen some LE floats in the wild (mainly [Saleae Binary Format](https://support.saleae.com/faq/technical-faq/binary-export-format-logic-2) ), so I decided to add them as well.